### PR TITLE
fix: export environment variables in zshenv

### DIFF
--- a/zshenv
+++ b/zshenv
@@ -6,7 +6,7 @@
 
 
 # To make it work on Ubuntu
-DEBIAN_PREVENT_KEYBOARD_CHANGES=yes
+export DEBIAN_PREVENT_KEYBOARD_CHANGES=yes
 
 # Use ~/.config directory
-XDG_CONFIG_HOME="$HOME/.config"
+export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"


### PR DESCRIPTION
## Summary
- `.zshenv`의 `DEBIAN_PREVENT_KEYBOARD_CHANGES`, `XDG_CONFIG_HOME`에 `export` 추가
- `export` 없이는 zsh 프로세스 내부에서만 보이고 자식 프로세스(git, 에디터 등)에 전파되지 않음
- 이미 설정된 `XDG_CONFIG_HOME`이 있으면 덮어쓰지 않도록 `${XDG_CONFIG_HOME:-...}` 패턴 적용

## Verification
- `zsh -n zshenv` 문법 검사 통과