### PR TITLE
fix: repair broken PATH guards and EDITOR detection in general.zshrc

### DIFF
--- a/general.zshrc
+++ b/general.zshrc
@@ -100,6 +100,12 @@ export XDG_CONFIG_HOME="$HOME/.config"
     [ -d $HOME/scripts ] && path=($HOME/scripts $path)
     [ -d $HOME/.rbenv/bin ] && path=($HOME/.rbenv/bin $path)
 
+    # Extend $PATH with mise shims so mise-managed tools are visible to
+    # non-interactive shells and to startup-time checks; `mise activate`
+    # swaps these for the real tool paths in interactive shells
+    [ -d ${XDG_DATA_HOME:-$HOME/.local/share}/mise/shims ] \
+      && path=(${XDG_DATA_HOME:-$HOME/.local/share}/mise/shims $path)
+
     if (( $+commands[rbenv] )); then
       eval "$(rbenv init - zsh)"
     fi

--- a/general.zshrc
+++ b/general.zshrc
@@ -6,11 +6,13 @@
 
 
 # Preferred editor for local and remote sessions
-if [[ -n $SSH_CONNECTION ]]; then
-  export EDITOR="$( echo $(which nvim) || echo $(which vim) || echo $(which vi) )"
-else
-  export EDITOR="$( echo $(which nvim) || echo $(which vim) || echo $(which vi) )"
-fi
+for _editor in nvim vim vi; do
+  if (( $+commands[$_editor] )); then
+    export EDITOR=$_editor
+    break
+  fi
+done
+unset _editor
 
 # Need to use gpg-agent with pinentry in macOS
 export GPG_TTY=$(tty)
@@ -42,9 +44,9 @@ export XDG_CONFIG_HOME="$HOME/.config"
   # Tell it where to save the history
   export HISTFILE=$HOME/.zsh_history
   # The number of lines from $HISTFILE to read at the start of an interactive session
-  export HISTSIZE=10000
+  export HISTSIZE=100000
   # The number of lines of your history you want saved
-  export SAVEHIST=10000
+  export SAVEHIST=100000
 
   # Ensure that commands are added to the history immediately
   setopt inc_append_history
@@ -52,18 +54,27 @@ export XDG_CONFIG_HOME="$HOME/.config"
   setopt extended_history
   # Skip duplicates while searching
   setopt hist_find_no_dups
+  # Remove older duplicates when a command is re-entered
+  setopt hist_ignore_all_dups
+  # Do not write duplicates to the history file
+  setopt hist_save_no_dups
+  # Remove superfluous blanks before recording
+  setopt hist_reduce_blanks
+  # Do not record commands starting with a space
+  setopt hist_ignore_space
 ### }}}
 
 
 ### Path {{{
-  if [ ! "$PATH_LOADED" = "true" ]; then
-    # Extend $PATH with Homebrew's sbin directory
-    [ ! "$PATH" = "*/usr/sbin*" ] && export PATH="/usr/sbin:$PATH"
-    [ ! "$PATH" = "*/usr/bin*" ] && export PATH="/usr/bin:$PATH"
-    [ ! "$PATH" = "*/usr/local/sbin*" ] && export PATH="/usr/local/sbin:$PATH"
-    [ ! "$PATH" = "*/usr/local/bin*" ] && export PATH="/usr/local/bin:$PATH"
+  # Keep entries in $path (and the tied $PATH) unique; the first occurrence wins
+  typeset -U path PATH
+  export PATH
 
-    if which kiro-cli > /dev/null; then
+  if [ ! "$PATH_LOADED" = "true" ]; then
+    # Extend $PATH with the system binary directories
+    path=(/usr/local/bin /usr/local/sbin /usr/bin /usr/sbin $path)
+
+    if (( $+commands[kiro-cli] )); then
       [[ -f "${HOME}/Library/Application Support/kiro-cli/shell/zshrc.pre.zsh" ]] && builtin source "${HOME}/Library/Application Support/kiro-cli/shell/zshrc.pre.zsh"
     fi
 
@@ -83,41 +94,41 @@ export XDG_CONFIG_HOME="$HOME/.config"
     ### }}}
 
     # Extend $PATH with user's binary paths in home directory
-    [ -d $HOME/.bin ] && export PATH="$HOME/.bin:$PATH"
-    [ -d $HOME/bin ] && export PATH="$HOME/bin:$PATH"
-    [ -d $HOME/.local/bin ] && export PATH="$HOME/.local/bin:$PATH"
-    [ -d $HOME/scripts ] && export PATH="$HOME/scripts:$PATH"
-    [ -d $HOME/.rbenv/bin ] && export PATH="$HOME/.rbenv/bin:$PATH"
+    [ -d $HOME/.bin ] && path=($HOME/.bin $path)
+    [ -d $HOME/bin ] && path=($HOME/bin $path)
+    [ -d $HOME/.local/bin ] && path=($HOME/.local/bin $path)
+    [ -d $HOME/scripts ] && path=($HOME/scripts $path)
+    [ -d $HOME/.rbenv/bin ] && path=($HOME/.rbenv/bin $path)
 
-    if which rbenv > /dev/null; then
+    if (( $+commands[rbenv] )); then
       eval "$(rbenv init - zsh)"
     fi
     # Extend $PATH with Ruby Gem's bin directory
-    if which ruby > /dev/null && which gem > /dev/null; then
-      PATH="$(ruby -r rubygems -e 'puts Gem.user_dir')/bin:$PATH"
+    if (( $+commands[ruby] )) && (( $+commands[gem] )); then
+      path=("$(ruby -r rubygems -e 'puts Gem.user_dir')/bin" $path)
     fi
 
     # Node.js
-    if which volta > /dev/null; then
+    if (( $+commands[volta] )); then
       export VOLTA_HOME=$HOME/.volta
 
       # Extend $PATH with volta's bin directory
-      export PATH="$VOLTA_HOME/bin:$PATH"
+      path=($VOLTA_HOME/bin $path)
     fi
 
-    if which kubectl > /dev/null; then
-      export PATH="$PATH:$HOME/.krew/bin"
+    if (( $+commands[kubectl] )); then
+      path+=($HOME/.krew/bin)
     fi
 
-    if which antigravity > /dev/null; then
-      export PATH="$PATH:$HOME/.antigravity/antigravity/bin"
+    if (( $+commands[antigravity] )); then
+      path+=($HOME/.antigravity/antigravity/bin)
     fi
 
     export PATH_LOADED="true"
   fi
 
   # Go PATH
-  if which go > /dev/null; then
+  if (( $+commands[go] )); then
     export GOPATH=$HOME/go
   fi
 ### }}}
@@ -140,8 +151,8 @@ export XDG_CONFIG_HOME="$HOME/.config"
   # Enable comments in interactive shell
   setopt interactive_comments
 
-  if which aws-vault > /dev/null; then
-    if which gopass > /dev/null; then
+  if (( $+commands[aws-vault] )); then
+    if (( $+commands[gopass] )); then
       export AWS_VAULT_BACKEND=pass
       export AWS_VAULT_PROMPT=osascript
       export AWS_VAULT_PASS_CMD=gopass
@@ -150,11 +161,11 @@ export XDG_CONFIG_HOME="$HOME/.config"
     fi
   fi
 
-  if which nvim > /dev/null; then
+  if (( $+commands[nvim] )); then
     export KUBE_EDITOR=nvim
   fi
 
-  if which zoxide > /dev/null; then
+  if (( $+commands[zoxide] )); then
     eval "$(zoxide init zsh)"
   fi
 ### }}}


### PR DESCRIPTION
## Summary
- **PATH 가드 버그 수정**: `[ ! "$PATH" = "*/usr/bin*" ]`는 `test`의 문자열 동등 비교라 glob 매칭이 일어나지 않아 항상 참(no-op)이었음 → `typeset -U path PATH` + `$path` 배열 조작으로 교체
- **EDITOR 감지 버그 수정**: `$( echo $(which nvim) || ... )`는 `echo`가 항상 성공해 폴백 체인이 작동하지 않았음 → nvim → vim → vi 폴백 루프로 교체
- 히스토리 개선: `HISTSIZE`/`SAVEHIST` 100,000 + 중복/공백 정리 옵션 추가
- `which cmd > /dev/null` → `(( $+commands[cmd] ))`
- **mise shims를 PATH에 추가** (아래 "mise 검토" 참고)

## `typeset -U path PATH`가 하는 일 (쉬운 설명)
zsh에서 `$PATH`(콜론으로 이어진 문자열)와 `$path`(배열)는 **같은 데이터의 두 가지 모습**입니다. 한쪽을 바꾸면 다른 쪽도 자동으로 바뀝니다 (tied variable).

`typeset -U`(Unique)는 이 변수에 **"중복 금지" 속성을 붙이는 선언**입니다. 한 번 선언해두면 이후 어떤 방식으로 경로를 추가하든 zsh가 자동으로 중복을 제거하며, **먼저 나온 항목(앞쪽)이 살아남습니다**. 즉 "PATH에 이미 있나?" 검사를 매번 직접 할 필요가 없어집니다 — 그 검사를 하려다 버그가 났던 기존 코드를 통째로 대체하는 선언 한 줄입니다.

## "이미 있는 경로를 또 prepend하면 중복 아닌가?"에 대한 답
중복되지 않습니다. 위 `-U` 속성 덕분에 `path=(/usr/bin ... $path)`처럼 이미 존재하는 경로를 다시 앞에 넣으면, **추가가 아니라 맨 앞으로 이동**하는 효과만 납니다. 실제 데모:

```
$ typeset -U path PATH
$ path=(/usr/bin /opt/test)
$ path=(/usr/local/bin /usr/bin $path)   # /usr/bin 중복 prepend 시도
$ echo $PATH
/usr/local/bin:/usr/bin:/opt/test        # /usr/bin은 한 번만 존재
```

소싱 후 `print -l $path | sort | uniq -d`로 중복 0건도 확인했습니다. 따라서 기존 가드 방식("없을 때만 추가")으로 되돌릴 필요가 없으며, 그 방식이 하려던 일을 `-U`가 대신합니다.

## mise 글로벌 도구 PATH 검토 결과
**결론: 도구별 PATH 등록은 필요 없지만, shims 디렉토리 추가는 필요해서 이 PR에 포함했습니다.**

- `mise activate zsh`(hook.zshrc)는 **첫 프롬프트의 precmd 훅에서야** PATH에 실제 도구 경로를 넣습니다. 따라서 인터랙티브 사용에는 등록이 불필요하지만, **zshrc 평가 시점**(`$+commands[terraform]` 같은 alias 가드)과 **비인터랙티브 셸**(스크립트, IDE)에서는 mise 도구가 보이지 않습니다 — `tf` alias가 안 잡히던 구조적 원인.
- mise 공식 문서가 이런 경우를 위해 권장하는 방식이 shims 디렉토리(`~/.local/share/mise/shims`)를 PATH에 두는 것이며, `mise activate`는 인터랙티브 셸에서 shims를 실제 경로로 교체하므로 둘은 충돌 없이 공존합니다.
- ⚠️ **별개의 환경 문제**: 현재 머신에서 terraform은 shim 자체가 생성되어 있지 않습니다. `mise WARN ... asdf-community/asdf-hashicorp ... registry not available` — 구 asdf 플러그인 백엔드가 깨진 상태라, `mise uninstall terraform && mise use -g terraform` 재설치(코어 백엔드 사용) 또는 `mise doctor` 점검이 필요합니다. 이건 레포 설정으로 해결되지 않습니다.

## Verification
- `zsh -n` 통과
- `env -u PATH_LOADED zsh -f`에서 소싱: shims PATH 등재, mise 관리 node가 rc 시점에 보임, PATH 중복 0건
- 실제 환경에서 `EDITOR=nvim`, 시스템/homebrew 경로 보존 확인