### PR TITLE
perf: run compinit once with daily cache and cache generated completions

### DIFF
--- a/completion.zshrc
+++ b/completion.zshrc
@@ -4,63 +4,94 @@
 # Maintained by Byungjin Park <posquit0.bj@gmail.com>
 # https://www.posquit0.com/
 
-autoload bashcompinit && bashcompinit
 
-if which brew > /dev/null; then
-  fpath+=$(brew --prefix)/share/zsh/site-functions
-fi
+### Completion System {{{
+  # Register extra completion directories BEFORE compinit so they are picked up
+  if (( $+commands[brew] )); then
+    fpath+=("$(brew --prefix)/share/zsh/site-functions")
+  fi
 
-mkdir -p "$HOME/.zfunc"
-fpath+="$HOME/.zfunc"
+  mkdir -p "$HOME/.zfunc"
+  fpath+=("$HOME/.zfunc")
+
+  # Initialize the completion system.
+  # Perform the full (secure) initialization only when the dump file is older
+  # than 24 hours; otherwise reuse the cached dump (-C) for a faster startup.
+  autoload -Uz compinit
+  if [[ -n ${ZDOTDIR:-$HOME}/.zcompdump(#qN.mh+24) ]]; then
+    compinit
+  else
+    compinit -C
+  fi
+
+  # Replay `compdef` calls that zinit queued for plugins loaded before compinit
+  (( $+functions[zinit] )) && zinit cdreplay -q
+
+  # Enable bash-style `complete` for tools that only ship bash completions
+  autoload -Uz bashcompinit && bashcompinit
+### }}}
+
+
+### Helpers {{{
+  # Generate a completion file only when it is missing or older than the tool
+  # binary, instead of regenerating it on every shell startup
+  function _completion_cache() {
+    local cmd=$1 target="$HOME/.zfunc/_$1"
+    shift
+    (( $+commands[$cmd] )) || return 0
+    if [[ ! -f $target || $target -ot ${commands[$cmd]} ]]; then
+      "$cmd" "$@" > "$target"
+    fi
+  }
+### }}}
+
 
 # Enable `mise` auto completion
-which mise > /dev/null \
-  && mise completion zsh > "$HOME/.zfunc/_mise"
+_completion_cache mise completion zsh
 
 # Enable `terraform` auto completion
-which terraform > /dev/null \
-  && complete -o nospace -C '$(which terraform)' terraform
+(( $+commands[terraform] )) \
+  && complete -o nospace -C "${commands[terraform]}" terraform
 
 # Enable `volta` auto completion
-which volta > /dev/null \
-  && volta completions zsh > "$HOME/.zfunc/_volta"
+_completion_cache volta completions zsh
 
 # Enable `packer` auto completion
-which packer > /dev/null \
-  && complete -o nospace -C '$(which packer)' packer
+(( $+commands[packer] )) \
+  && complete -o nospace -C "${commands[packer]}" packer
 
 # Enable `skaffold` auto completion
-which skaffold > /dev/null \
+(( $+commands[skaffold] )) \
   && eval "$(skaffold completion zsh)"
 
 # Enable `kaf` auto completion
-which kaf > /dev/null \
-  && kaf completion zsh > "$HOME/.zfunc/_kaf"
+_completion_cache kaf completion zsh
 
 # Enable `kubebuilder` auto completion
-which kubebuilder > /dev/null \
+(( $+commands[kubebuilder] )) \
   && eval "$(kubebuilder completion zsh)"
 
-if which switcher > /dev/null; then
+if (( $+commands[switcher] )); then
   source <(switcher init zsh)
-  source <(compdef _switcher switch)
+  compdef _switcher switch
   source <(switch completion zsh)
 fi
 
 # Enable `aws` auto completion
-which aws > /dev/null \
-  && complete -C '$(which aws_completer)' aws
+(( $+commands[aws] && $+commands[aws_completer] )) \
+  && complete -C "${commands[aws_completer]}" aws
 
 # Enable `aws-vault` auto completion
-which aws-vault > /dev/null \
+(( $+commands[aws-vault] )) \
   && eval "$(aws-vault --completion-script-zsh)"
 
 # Enable `poetry` auto completion
-which poetry > /dev/null \
-  && poetry completions zsh > "$HOME/.zfunc/_poetry"
+_completion_cache poetry completions zsh
 
 # Enable `pipenv` auto completion
-which pipenv > /dev/null \
+(( $+commands[pipenv] )) \
   && eval "$(_PIPENV_COMPLETE=zsh_source pipenv)"
 # Creating the virtualenv inside project’s directory
 export PIPENV_VENV_IN_PROJECT=1
+
+unfunction _completion_cache

--- a/completion.zshrc
+++ b/completion.zshrc
@@ -15,8 +15,13 @@
   fpath+=("$HOME/.zfunc")
 
   # Initialize the completion system.
-  # Perform the full (secure) initialization only when the dump file is older
-  # than 24 hours; otherwise reuse the cached dump (-C) for a faster startup.
+  # compinit scans every directory in $fpath and writes the result to a cache
+  # file (~/.zcompdump). The scan is the slow part, so run it at most once a
+  # day; otherwise reuse the cache as-is with -C, which skips the scan.
+  #
+  # The condition is a zsh glob, not a regex. It reads as: "does a plain
+  # file (.) named .zcompdump, modified more than 24 hours ago (mh+24),
+  # exist (N: expand to nothing instead of erroring when it does not)?"
   autoload -Uz compinit
   if [[ -n ${ZDOTDIR:-$HOME}/.zcompdump(#qN.mh+24) ]]; then
     compinit
@@ -33,8 +38,11 @@
 
 
 ### Helpers {{{
-  # Generate a completion file only when it is missing or older than the tool
-  # binary, instead of regenerating it on every shell startup
+  # Usage: _completion_cache <command> <args...>
+  # Saves the output of `<command> <args...>` as the completion file
+  # ~/.zfunc/_<command>, but only when that file is missing or older than
+  # the command's binary (i.e. the tool was upgraded since the last run).
+  # This replaces regenerating every completion file on every shell startup.
   function _completion_cache() {
     local cmd=$1 target="$HOME/.zfunc/_$1"
     shift
@@ -93,5 +101,3 @@ _completion_cache poetry completions zsh
   && eval "$(_PIPENV_COMPLETE=zsh_source pipenv)"
 # Creating the virtualenv inside project’s directory
 export PIPENV_VENV_IN_PROJECT=1
-
-unfunction _completion_cache

--- a/plugins.zshrc
+++ b/plugins.zshrc
@@ -15,7 +15,9 @@ zinit snippet OMZ::plugins/git/git.plugin.zsh
   # Fish shell-like syntax highlighting for Zsh
   # INFO: Alternative of `zsh-syntax-highlighting`
 
-  zinit ice wait lucid atinit"zpcompinit; zpcdreplay"
+  # NOTE: compinit runs once in completion.zshrc (before turbo plugins fire),
+  # so no `zicompinit` is needed here anymore
+  zinit ice wait lucid
   zinit light zdharma-continuum/fast-syntax-highlighting
 ### }}}
 

--- a/plugins.zshrc
+++ b/plugins.zshrc
@@ -15,8 +15,6 @@ zinit snippet OMZ::plugins/git/git.plugin.zsh
   # Fish shell-like syntax highlighting for Zsh
   # INFO: Alternative of `zsh-syntax-highlighting`
 
-  # NOTE: compinit runs once in completion.zshrc (before turbo plugins fire),
-  # so no `zicompinit` is needed here anymore
   zinit ice wait lucid
   zinit light zdharma-continuum/fast-syntax-highlighting
 ### }}}

--- a/zshrc
+++ b/zshrc
@@ -8,7 +8,8 @@
 # Set the path of zsh configuration directory
 export ZSH_HOME=$HOME/.zsh
 
-autoload -Uz compinit && compinit
+# NOTE: compinit is invoked once in completion.zshrc, after all fpath entries
+# are registered; running it here as well doubles the startup cost.
 
 # Load a general configuration of zsh
 [ -f $ZSH_HOME/general.zshrc ] && source $ZSH_HOME/general.zshrc

--- a/zshrc
+++ b/zshrc
@@ -8,9 +8,6 @@
 # Set the path of zsh configuration directory
 export ZSH_HOME=$HOME/.zsh
 
-# NOTE: compinit is invoked once in completion.zshrc, after all fpath entries
-# are registered; running it here as well doubles the startup cost.
-
 # Load a general configuration of zsh
 [ -f $ZSH_HOME/general.zshrc ] && source $ZSH_HOME/general.zshrc
 


### PR DESCRIPTION
## 배경 지식: compinit과 .zcompdump가 뭐길래

- **compinit** = zsh 자동완성 시스템의 초기화 명령. 실행되면 `$fpath`에 등록된 모든 디렉토리를 스캔해서 "어떤 명령에 어떤 자동완성 함수를 쓸지" 색인을 만듭니다. **이 스캔이 셸 시작에서 가장 느린 작업 중 하나**입니다 (수십~수백 ms).
- **.zcompdump** = 그 색인을 저장해두는 캐시 파일.
- **규칙**: fpath 등록은 반드시 compinit **전에** 끝나야 합니다. compinit이 실행되는 순간의 fpath만 색인에 들어가기 때문입니다.

## 기존 코드의 문제 2가지

**문제 1 — compinit이 매번 두 번 실행됨 (속도 낭비)**
- 1번째: `zshrc` 11행에서 직접 실행
- 2번째: zinit이 fast-syntax-highlighting을 로드할 때 `zpcompinit`으로 또 실행

**문제 2 — 1번째 compinit은 사실 무의미했음 (순서 버그)**
1번째 compinit은 `completion.zshrc`가 brew site-functions와 `~/.zfunc`를 fpath에 등록하기 **전에** 실행됩니다. 즉 그 시점의 색인에는 brew로 설치한 도구들의 자동완성이 빠져 있습니다. 그런데도 지금까지 자동완성이 됐던 이유는 **2번째 compinit이 fpath 등록 이후에 실행되면서 색인을 다시 만들어줬기 때문**입니다. 다시 말해, 이중 실행(문제 1)이 순서 버그(문제 2)를 우연히 가려주고 있던 구조라 한쪽만 고치면 안 되고 함께 고쳐야 합니다.

## 변경 내용 (3가지)

**1. compinit을 "fpath 등록이 모두 끝난 뒤, 딱 한 번"만 실행**
- `zshrc`의 compinit 제거, zinit의 `zpcompinit`도 제거
- `completion.zshrc`에서 fpath 등록 직후에 한 번만 실행

**2. 색인 재생성은 하루에 한 번만**
```zsh
if [[ -n ${ZDOTDIR:-$HOME}/.zcompdump(#qN.mh+24) ]]; then
  compinit      # 캐시가 24시간보다 오래됨 → 전체 스캔으로 재생성
else
  compinit -C   # 캐시가 신선함 → 스캔 생략하고 캐시 그대로 사용
fi
```
조건문이 암호처럼 보이는데 정규식이 아니라 zsh 글롭입니다: ".zcompdump라는 **일반 파일**(`.`)이 **24시간보다 오래 전에 수정된 상태로**(`mh+24`) 존재하는가? (`N`: 없으면 에러 대신 빈 값)" — zsh 커뮤니티에서 표준처럼 쓰이는 관용구라 직접 발명한 코드가 아니며, 코드 주석에도 같은 설명을 달아뒀습니다.

**3. 자동완성 파일 생성도 캐싱**
기존에는 셸을 열 때마다 `mise completion zsh > ~/.zfunc/_mise` 처럼 **mise/volta/kaf/poetry 4개 프로그램을 매번 실행해서 매번 같은 파일을 다시 만들었습니다** (각각 수십 ms). 이제 `_completion_cache` 헬퍼가 "파일이 없거나, 도구 바이너리가 파일보다 새것일 때(=업그레이드했을 때)"만 재생성합니다. 도구를 업그레이드하면 자동으로 갱신되므로 수동 관리도 필요 없습니다.

부수 변경: `zinit cdreplay -q`는 compinit보다 먼저 로드된 플러그인들이 등록 시도한 자동완성(compdef)을 compinit 이후에 재생해주는 zinit 공식 패턴입니다.

## 복잡도에 대한 솔직한 평가
리뷰 의견 반영해 두 군데를 단순화했습니다 (fa757c3): 글롭 한정자에 토큰별 설명 주석 추가, 사용 후 헬퍼 함수를 지우던 `unfunction` 트릭 제거(함수 하나 남겨두는 비용은 0인데 읽는 사람만 헷갈리게 함). 남은 구조 — "fpath 전부 등록 → compinit 1회 → cdreplay" 순서와 24시간 캐시 글롭 — 는 zsh/zinit 생태계의 표준 패턴이라, 더 단순하게 바꾸면(예: 캐시 없이 매번 전체 스캔) 이 PR의 목적인 시작 속도를 다시 잃습니다.

## Verification
- `zsh -n` 통과 (zshrc / completion.zshrc / plugins.zshrc)
- 실제 인터랙티브 zsh 스모크 테스트: compinit 1회 실행 확인(`_main_complete` 존재), `compdef`/bashcompinit 정상, `.zcompdump` 생성, `_mise` 캐시 파일 생성 확인