### PR TITLE
feat: replace unmaintained plugins with maintained alternatives

### DIFF
--- a/plugins.zshrc
+++ b/plugins.zshrc
@@ -19,11 +19,11 @@ zinit snippet OMZ::plugins/git/git.plugin.zsh
   zinit light zdharma-continuum/fast-syntax-highlighting
 ### }}}
 
-### Plugin: Autosuggentions {{{
+### Plugin: Autosuggestions {{{
   # Fish-like autosuggestions for zsh
   ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE="fg=244"
   ZSH_AUTOSUGGEST_STRATEGY=(history completion)
-  ZSH_AUTOSUGGEST_USE_ASYNC=true
+  # NOTE: async mode is the default since v0.7.0; no need to set it explicitly
 
   zinit ice wait"0b" lucid atload'
     _zsh_autosuggest_start
@@ -40,16 +40,22 @@ zinit snippet OMZ::plugins/git/git.plugin.zsh
   zinit light zsh-users/zsh-completions
 ### }}}
 
-### Plugin: Alias Tips {{{
-  # Help remembering those aliases you defined once
-  zinit ice from'gh-r' as 'program'
-  zinit light decayofmind/zsh-fast-alias-tips
-  export ZSH_FAST_ALIAS_TIPS_PREFIX="💡 Alias: $(tput bold)"
+### Plugin: You Should Use {{{
+  # Reminds you of your existing aliases when you type the aliased command
+  # INFO: Replaces `decayofmind/zsh-fast-alias-tips` (unmaintained since 2025)
+  YSU_MESSAGE_POSITION="after"
+  YSU_MODE=ALL
+
+  zinit ice wait lucid
+  zinit light MichaelAquilina/zsh-you-should-use
 ### }}}
 
 ### Plugin: History Substring Search {{{
   # ZSH port of Fish history search
   # INFO: zsh-history-substring-search should be after zsh-syntax-highlighting
+  # Do not show the same result twice while cycling through matches
+  HISTORY_SUBSTRING_SEARCH_ENSURE_UNIQUE=1
+
   zinit ice wait lucid atload'
     bindkey "^P" history-substring-search-up
     bindkey "^N" history-substring-search-down
@@ -74,14 +80,6 @@ zinit snippet OMZ::plugins/git/git.plugin.zsh
   zinit light jeffreytse/zsh-vi-mode
 ### }}}
 
-### Plugin: GitHub Copilot {{{
-  ZSH_GH_COPILOT_NO_CHECK=1
-  # GitHub Copilot for your command line
-  zinit light loiccoyle/zsh-github-copilot
-  bindkey '»' zsh_gh_copilot_explain  # bind Option+shift+\ to explain
-  bindkey '«' zsh_gh_copilot_suggest  # bind Option+\ to suggest
-### }}}
-
 ### Integration: FZF {{{
   zinit ice lucid wait"0" atload'eval "$(fzf --zsh)"'
   zinit light junegunn/fzf
@@ -104,8 +102,11 @@ zinit snippet OMZ::plugins/git/git.plugin.zsh
   zinit light Aloxaf/fzf-tab
 ### }}}
 
-### Plugin: Calc {{{
-  # Support for basic math
-  zinit ice wait"1" lucid
-  zinit light arzzen/calc.plugin.zsh
+### Calc {{{
+  # Support for basic math with zsh built-ins
+  # INFO: Replaces `arzzen/calc.plugin.zsh` (unmaintained since 2024)
+  # Interactive calculator: run `zcalc`
+  autoload -Uz zcalc
+  # Inline calculator (usage: `= 2 * (3 + 4)`)
+  function = { echo $(( $* )) }
 ### }}}


### PR DESCRIPTION
## Summary
2026-06-12 기준 GitHub API/공식 changelog로 각 플러그인의 유지보수 상태를 확인한 결과입니다.

- **zsh-github-copilot 제거**: 의존하는 `gh-copilot` 확장이 2025-10-25에 서비스 종료되어 플러그인이 사실상 깨진 상태 ([GitHub changelog](https://github.blog/changelog/2025-09-25-upcoming-deprecation-of-gh-copilot-cli-extension/)). 대체는 독립형 GitHub Copilot CLI(`npm i -g @github/copilot`)로 zsh 플러그인 불필요
- **zsh-fast-alias-tips → [zsh-you-should-use](https://github.com/MichaelAquilina/zsh-you-should-use)**: 전자는 스타 15개, 2025년 1월 이후 방치, Go 바이너리 필요. 후자는 ~1.9k 스타, 2026년 5월까지 활발히 유지보수, 순수 zsh
- **calc.plugin.zsh → 내장 `zcalc` + `=` 함수**: 2024년 7월 이후 방치. zsh 내장 기능으로 동일 동작(`= 2 * (3 + 4)`) 재현
- `ZSH_AUTOSUGGEST_USE_ASYNC` 제거: zsh-autosuggestions v0.7.0부터 async가 기본값
- `HISTORY_SUBSTRING_SEARCH_ENSURE_UNIQUE=1` 추가 (README 권장)

## Note (변경하지 않은 제안)
- `fast-syntax-highlighting`은 2025-07 이후 커밋이 없어 장기적으로는 `zsh-users/zsh-syntax-highlighting`(22.7k 스타, 2026-02 커밋)이 더 안전하나, 속도/기능 우위로 유지함

## Verification
- `zsh -n` 통과, `=` 함수와 `zcalc` autoload 동작 확인