### PR TITLE
refactor: modernize command checks in aliases, hook and prompt configs

### DIFF
--- a/aliases.zshrc
+++ b/aliases.zshrc
@@ -28,47 +28,47 @@ alias ssh="ssh -A"
 [ -f /opt/homebrew/bin/brew ] \
   && alias abrew=/opt/homebrew/bin/brew
 
-which chezmoi > /dev/null \
+(( $+commands[chezmoi] )) \
   && alias cz=chezmoi
 
-which zellij > /dev/null \
+(( $+commands[zellij] )) \
   && alias zj=zellij
 
-which htop > /dev/null \
+(( $+commands[htop] )) \
   && alias top=htop
 
-which docker > /dev/null \
+(( $+commands[docker] )) \
   && alias d=docker
 
-which kubectl > /dev/null \
+(( $+commands[kubectl] )) \
   && alias k=kubectl
 
-which switch > /dev/null \
+(( $+commands[switch] )) \
   && alias ks=switch
 
-which eza > /dev/null \
+(( $+commands[eza] )) \
   && alias ls=eza
 
-which lazygit > /dev/null \
+(( $+commands[lazygit] )) \
   && alias g=lazygit
 
-which nvim > /dev/null \
+(( $+commands[nvim] )) \
   && alias vim=nvim
 
-which terraform > /dev/null \
+(( $+commands[terraform] )) \
   && alias tf=terraform
 
-which packer > /dev/null \
+(( $+commands[packer] )) \
   && alias pkr=packer
 
-which pinentry-mac > /dev/null \
+(( $+commands[pinentry-mac] )) \
   && alias pinentry=pinentry-mac
 
-which gopass > /dev/null \
+(( $+commands[gopass] )) \
   && alias pass=gopass
 
-which claude-squad > /dev/null \
+(( $+commands[claude-squad] )) \
   && alias cs=claude-squad
 
-which grealpath > /dev/null \
+(( $+commands[grealpath] )) \
   && alias realpath=grealpath

--- a/hook.zshrc
+++ b/hook.zshrc
@@ -5,17 +5,24 @@
 # https://www.posquit0.com/
 
 
+# `add-zsh-hook` is not loaded by default; do not rely on plugins to do it
+autoload -Uz add-zsh-hook
+
+# Enable `tfswitch` hook
 load-tfswitch() {
-  [ -f ".terraform-version" ] && tfswitch
-  [ -f "versions.tf" ] && tfswitch
+  if [ -f ".terraform-version" ] || [ -f "versions.tf" ]; then
+    tfswitch
+  fi
 }
-which tfswitch > /dev/null \
-  && add-zsh-hook chpwd load-tfswitch
+if (( $+commands[tfswitch] )); then
+  add-zsh-hook chpwd load-tfswitch
+  load-tfswitch
+fi
 
 # Enable `direnv` hook
-which direnv > /dev/null \
+(( $+commands[direnv] )) \
   && eval "$(direnv hook zsh)"
 
 # Enable `mise` hook
-which mise > /dev/null \
+(( $+commands[mise] )) \
   && eval "$(mise activate zsh)"

--- a/prompt.zshrc
+++ b/prompt.zshrc
@@ -5,5 +5,5 @@
 # https://www.posquit0.com/
 
 
-which starship > /dev/null \
+(( $+commands[starship] )) \
   && eval "$(starship init zsh)"


### PR DESCRIPTION
## Summary
- `which cmd > /dev/null`(fork 발생, POSIX 미규정) → zsh 네이티브 `(( $+commands[cmd] ))` 해시 조회로 교체 (aliases.zshrc, hook.zshrc, prompt.zshrc)
- hook.zshrc: `add-zsh-hook`를 명시적으로 `autoload -Uz` (기존엔 플러그인 매니저가 로드해주는 것에 암묵적으로 의존)
- tfswitch 훅: `.terraform-version`과 `versions.tf`가 둘 다 있을 때 두 번 실행되던 것을 한 번으로, 셸 시작 시 현재 디렉토리에 대해서도 1회 실행 (작성자 권장 패턴)

## Verification
- `zsh -n` 통과 (3개 파일 모두)