### PR TITLE
fix: detect the switch shell function when defining the ks alias

### DIFF
--- a/aliases.zshrc
+++ b/aliases.zshrc
@@ -43,7 +43,9 @@ alias ssh="ssh -A"
 (( $+commands[kubectl] )) \
   && alias k=kubectl
 
-(( $+commands[switch] )) \
+# `switch` is a shell function defined by `switcher init zsh`, not a binary,
+# so the function table must be checked as well
+(( $+commands[switch] || $+functions[switch] )) \
   && alias ks=switch
 
 (( $+commands[eza] )) \


### PR DESCRIPTION
## Summary
#6 위에 스택된 후속 수정입니다 (base: `refactor/command-checks`).

- `switch`는 외부 바이너리가 아니라 kubeswitch의 `switcher init zsh`(completion.zshrc)가 정의하는 **셸 함수**라서, `(( $+commands[switch] ))`는 항상 0이 되어 `ks` alias가 정의되지 않는 회귀가 있었음
- `$+functions[switch]`를 함께 확인하도록 수정

배경: zsh의 `which`(= `whence -c` builtin)는 함수/alias/builtin까지 찾지만 `$commands`는 PATH상의 외부 실행 파일만 조회하므로, 함수로 정의되는 이름에는 `$+functions` 병행이 필요합니다.

## Verification
- `zsh -n` 통과
- 실제 셸에서 `switcher init zsh` 후 소싱하여 `ks=switch` 정의 확인