### PR TITLE
feat: prefer the mise hook over direnv

### DIFF
--- a/hook.zshrc
+++ b/hook.zshrc
@@ -19,10 +19,10 @@ if (( $+commands[tfswitch] )); then
   load-tfswitch
 fi
 
-# Enable `direnv` hook
-(( $+commands[direnv] )) \
-  && eval "$(direnv hook zsh)"
-
-# Enable `mise` hook
-(( $+commands[mise] )) \
-  && eval "$(mise activate zsh)"
+# Enable the `mise` hook, falling back to `direnv` when mise is not
+# installed; mise covers direnv's use case so both hooks are not needed
+if (( $+commands[mise] )); then
+  eval "$(mise activate zsh)"
+elif (( $+commands[direnv] )); then
+  eval "$(direnv hook zsh)"
+fi


### PR DESCRIPTION
## Summary
- `mise`가 설치되어 있으면 `mise activate zsh`만 실행하고, 없을 때만 `direnv hook zsh`로 폴백하도록 변경
- 기존에는 두 훅을 무조건 둘 다 등록 → mise가 direnv의 per-directory 환경 기능을 커버하므로 매 프롬프트마다 두 훅을 모두 실행하는 것은 중복

```zsh
if (( $+commands[mise] )); then
  eval "$(mise activate zsh)"
elif (( $+commands[direnv] )); then
  eval "$(direnv hook zsh)"
fi
```

## Note
- 기존에 `.envrc`를 쓰는 프로젝트가 있다면 mise의 `.envrc` 지원(`mise settings experimental` 여부에 따라 다름) 또는 `.mise.toml`의 `[env]`로 옮겨야 동작합니다. direnv 훅이 더 이상 로드되지 않기 때문입니다 — 이 점이 의도와 다르면 알려주세요.

## Verification
- `zsh -n` 통과
- 깨끗한 `zsh -f` 셸에서 소싱: `_mise_hook` 활성 + `_direnv_hook` 미로드 확인