### PR TITLE
feat: add ai.zshrc with claude-powered command suggest/explain widgets

### DIFF
--- a/ai.zshrc
+++ b/ai.zshrc
@@ -1,0 +1,56 @@
+# vi: filetype=zsh
+# ai.zshrc
+#
+# Maintained by Byungjin Park <posquit0.bj@gmail.com>
+# https://www.posquit0.com/
+#
+# LLM assistance on the command line via the `claude` CLI.
+# Replaces the defunct `zsh-github-copilot` plugin (its gh-copilot
+# backend was shut down by GitHub on 2025-10-25).
+
+(( $+commands[claude] )) || return 0
+
+# Model for the inline helpers; haiku is the fastest tier
+: ${ZSH_AI_MODEL:=haiku}
+
+# Turn the natural-language description in the buffer into a zsh command
+zsh-ai-suggest() {
+  [[ -z $BUFFER ]] && return 0
+  zle -M "🤖 Suggesting a command for: $BUFFER"
+  local suggestion
+  suggestion=$(claude -p --model "$ZSH_AI_MODEL" \
+    "You are a zsh command generator. Reply with a single zsh command only: no code fences, no backticks, no explanation. Task: $BUFFER" 2>/dev/null)
+  if [[ -n $suggestion ]]; then
+    BUFFER=$suggestion
+    CURSOR=$#BUFFER
+    zle reset-prompt
+  else
+    zle -M "claude returned no suggestion; check \`claude /login\` or quota"
+  fi
+}
+
+# Explain the command currently in the buffer
+zsh-ai-explain() {
+  [[ -z $BUFFER ]] && return 0
+  zle -M "🤖 Explaining: $BUFFER"
+  local explanation
+  explanation=$(claude -p --model "$ZSH_AI_MODEL" \
+    "Explain what this zsh command does, briefly and in plain text (no markdown): $BUFFER" 2>/dev/null)
+  zle -M "${explanation:-claude returned no explanation; check \`claude /login\` or quota}"
+}
+
+zle -N zsh-ai-suggest
+zle -N zsh-ai-explain
+
+_zsh_ai_bind_keys() {
+  bindkey '«' zsh-ai-suggest  # Option+\ on macOS
+  bindkey '»' zsh-ai-explain  # Option+Shift+\ on macOS
+}
+
+if (( $+functions[zvm_init] )); then
+  # zsh-vi-mode rebuilds keymaps when it initializes at the first prompt,
+  # which would drop bindings made here; register them to run afterwards
+  zvm_after_init_commands+=(_zsh_ai_bind_keys)
+else
+  _zsh_ai_bind_keys
+fi

--- a/ai.zshrc
+++ b/ai.zshrc
@@ -3,10 +3,6 @@
 #
 # Maintained by Byungjin Park <posquit0.bj@gmail.com>
 # https://www.posquit0.com/
-#
-# LLM assistance on the command line via the `claude` CLI.
-# Replaces the defunct `zsh-github-copilot` plugin (its gh-copilot
-# backend was shut down by GitHub on 2025-10-25).
 
 (( $+commands[claude] )) || return 0
 

--- a/zshrc
+++ b/zshrc
@@ -31,6 +31,9 @@ autoload -Uz compinit && compinit
 # Load an alias configuration of zsh
 [ -f $ZSH_HOME/aliases.zshrc ] && source $ZSH_HOME/aliases.zshrc
 
+# Load an AI assistance configuration of zsh
+[ -f $ZSH_HOME/ai.zshrc ] && source $ZSH_HOME/ai.zshrc
+
 # Load a general alias configuration
 [ -f $HOME/.alias ] && source $HOME/.alias
 


### PR DESCRIPTION
## Summary
제거된 `zsh-github-copilot`(#5)의 대체로, `claude` CLI의 비대화형 모드(`claude -p`)를 감싼 zle 위젯 2개를 새 `ai.zshrc` 파일로 추가합니다. 기존 Claude Code 구독을 그대로 사용하므로 별도 API 키가 필요 없습니다.

- **`Option+\`** (`zsh-ai-suggest`): 버퍼의 자연어 설명을 그 자리에서 zsh 명령어로 치환
- **`Option+Shift+\`** (`zsh-ai-explain`): 버퍼의 명령어 설명을 프롬프트 아래에 표시
- 키는 기존 zsh-github-copilot과 동일한 `«`/`»` 사용 (macOS Option 키 조합)
- 모델은 `ZSH_AI_MODEL`로 설정 가능 (기본 `haiku`, 응답 ~수 초)
- `claude` 미설치 시 전체 파일이 조용히 스킵됨 (`(( $+commands[claude] )) || return 0`)
- **zsh-vi-mode 호환**: zvm은 첫 프롬프트에서 키맵을 재구성하며 기존 바인딩을 덮어쓰므로, zvm 존재 시 `zvm_after_init_commands`를 통해 바인딩 (zvm README 권장 패턴)
- `zshrc`에서 aliases 다음에 `ai.zshrc` 로딩 추가

## Verification
- `zsh -n` 통과 (ai.zshrc, zshrc)
- `claude -p --model haiku` 실호출 테스트: 명령어만 깔끔히 출력, ~6초
- 인터랙티브 셸 검증: zvm 환경에서 위젯 등록 + `zvm_after_init_commands`에 바인딩 함수 등록 확인, plain zsh에서 `«`/`»` 직접 바인딩 확인

## Security self-check
- 버퍼 내용이 Anthropic API로 전송됨 — 비밀번호/토큰을 버퍼에 둔 채 위젯을 호출하지 않도록 주의 필요
- 제안된 명령은 자동 실행되지 않고 버퍼에 올라올 뿐이므로 실행 전 사용자 검토(human-in-the-loop) 보장
- 셸 인젝션 없음: 버퍼는 인자로만 전달, eval 미사용