### PR TITLE
feat: show an animated spinner while waiting for the AI response

### DIFF
--- a/ai.zshrc
+++ b/ai.zshrc
@@ -9,18 +9,52 @@
 # Model for the inline helpers; haiku is the fastest tier
 : ${ZSH_AI_MODEL:=haiku}
 
+# zselect sleeps without forking; fall back to `sleep` when unavailable
+zmodload zsh/zselect 2>/dev/null && typeset -g _ZSH_AI_HAS_ZSELECT=1
+
+# Run `claude -p` in the background, animating a spinner until it finishes.
+# The response is stored in $_ZSH_AI_RESPONSE; returns non-zero when the
+# response is empty, or 130 when cancelled with Ctrl+C.
+_zsh_ai_request() {
+  local prompt=$1 label=$2
+  local tmp pid
+  tmp=$(mktemp) || return 1
+  typeset -g _ZSH_AI_RESPONSE=
+
+  claude -p --model "$ZSH_AI_MODEL" "$prompt" > "$tmp" 2>/dev/null &!
+  pid=$!
+
+  # Kill the request and clean up when the user cancels with Ctrl+C
+  trap "kill $pid 2>/dev/null; command rm -f '$tmp'; zle -M 'cancelled'; return 130" INT
+
+  local -a frames=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')
+  local i=1 start=$SECONDS
+  while kill -0 $pid 2>/dev/null; do
+    zle -M "${frames[i]} ${label} [${ZSH_AI_MODEL}, $(( SECONDS - start ))s, Ctrl+C to cancel]"
+    (( i = i % $#frames + 1 ))
+    if [[ -n $_ZSH_AI_HAS_ZSELECT ]]; then
+      zselect -t 10  # centiseconds
+    else
+      command sleep 0.1
+    fi
+  done
+  trap - INT
+
+  _ZSH_AI_RESPONSE=$(<"$tmp")
+  command rm -f "$tmp"
+  [[ -n $_ZSH_AI_RESPONSE ]]
+}
+
 # Turn the natural-language description in the buffer into a zsh command
 zsh-ai-suggest() {
   [[ -z $BUFFER ]] && return 0
-  zle -M "🤖 Suggesting a command for: $BUFFER"
-  local suggestion
-  suggestion=$(claude -p --model "$ZSH_AI_MODEL" \
-    "You are a zsh command generator. Reply with a single zsh command only: no code fences, no backticks, no explanation. Task: $BUFFER" 2>/dev/null)
-  if [[ -n $suggestion ]]; then
-    BUFFER=$suggestion
+  if _zsh_ai_request \
+    "You are a zsh command generator. Reply with a single zsh command only: no code fences, no backticks, no explanation. Task: $BUFFER" \
+    "🤖 Suggesting a command for: $BUFFER"; then
+    BUFFER=$_ZSH_AI_RESPONSE
     CURSOR=$#BUFFER
     zle reset-prompt
-  else
+  elif (( $? != 130 )); then
     zle -M "claude returned no suggestion; check \`claude /login\` or quota"
   fi
 }
@@ -28,11 +62,13 @@ zsh-ai-suggest() {
 # Explain the command currently in the buffer
 zsh-ai-explain() {
   [[ -z $BUFFER ]] && return 0
-  zle -M "🤖 Explaining: $BUFFER"
-  local explanation
-  explanation=$(claude -p --model "$ZSH_AI_MODEL" \
-    "Explain what this zsh command does, briefly and in plain text (no markdown): $BUFFER" 2>/dev/null)
-  zle -M "${explanation:-claude returned no explanation; check \`claude /login\` or quota}"
+  if _zsh_ai_request \
+    "Explain what this zsh command does, briefly and in plain text (no markdown): $BUFFER" \
+    "🤖 Explaining: $BUFFER"; then
+    zle -M "$_ZSH_AI_RESPONSE"
+  elif (( $? != 130 )); then
+    zle -M "claude returned no explanation; check \`claude /login\` or quota"
+  fi
 }
 
 zle -N zsh-ai-suggest


### PR DESCRIPTION
## Summary
기존에는 단축키를 누르면 정적 메시지 한 줄만 표시된 채 `claude -p`가 끝날 때까지(수 초) 셸이 멈춘 것처럼 보였습니다. 이제 진행 상황이 실시간으로 보입니다:

```
⠹ 🤖 Suggesting a command for: find big files [haiku, 3s, Ctrl+C to cancel]
```

### 구현
- `claude -p`를 **disowned 백그라운드 잡**(`&!`)으로 실행하고, 위젯이 `kill -0`으로 폴링하며 0.1초마다 `zle -M`으로 점자 스피너 + 경과 시간(초)을 다시 그림
- 프레임 간 대기는 `zsh/zselect` 모듈 사용 (fork 없음) — 모듈이 없는 환경에서는 `sleep 0.1` 폴백
- **Ctrl+C로 요청 취소 가능** (신규 기능): INT trap이 백그라운드 잡을 kill하고 임시 파일을 정리한 뒤 `cancelled` 표시. 취소 시(exit 130)에는 "no response" 에러 메시지를 띄우지 않도록 분기
- 공통 로직을 `_zsh_ai_request` 헬퍼로 추출 — suggest/explain 두 위젯이 공유. 응답은 서브셸 캡처(`$(...)`) 대신 전역 `$_ZSH_AI_RESPONSE`로 전달하는데, 서브셸 안에서는 `zle` 호출이 불가하기 때문

## Verification
- `zsh -n` 통과
- `zle` 스텁 + 1.2초짜리 가짜 `claude`로 메커니즘 검증: 12프레임(0.1s 간격) 갱신, 응답 정상 수집, status 0
- 실제 `claude` 바이너리로 end-to-end: `response=[pong]`, status 0
- Ctrl+C 취소 경로는 trap 로직 특성상 headless 검증이 어려워 머지 후 실사용 확인 권장

## Security self-check
- 기존과 동일하게 버퍼 내용이 Anthropic API로 전송됨 (suggest/explain 호출 시에만)
- 임시 파일은 `mktemp` 사용, 정상/취소 경로 모두에서 삭제
- 제안 명령은 버퍼 삽입만 — 자동 실행 없음 (human-in-the-loop 유지)