### PR TITLE
fix: keep the AI spinner status on a single line

### DIFF
--- a/ai.zshrc
+++ b/ai.zshrc
@@ -21,6 +21,12 @@ _zsh_ai_request() {
   tmp=$(mktemp) || return 1
   typeset -g _ZSH_AI_RESPONSE=
 
+  # The status message must stay on one physical line: when it wraps, zle's
+  # message area grows and every redraw leaves the previous frame on screen
+  # as a ghost line. Strip newlines from the label here; width-based
+  # truncation happens per frame below.
+  label=${label//$'\n'/ }
+
   claude -p --model "$ZSH_AI_MODEL" "$prompt" > "$tmp" 2>/dev/null &!
   pid=$!
 
@@ -29,8 +35,14 @@ _zsh_ai_request() {
 
   local -a frames=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')
   local i=1 start=$SECONDS
+  local msg suffix max
   while kill -0 $pid 2>/dev/null; do
-    zle -M "${frames[i]} ${label} [${ZSH_AI_MODEL}, $(( SECONDS - start ))s, Ctrl+C to cancel]"
+    suffix=" [${ZSH_AI_MODEL}, $(( SECONDS - start ))s, Ctrl+C to cancel]"
+    msg="${frames[i]} ${label}"
+    # -3 leaves room for the ellipsis and double-width characters (emoji)
+    max=$(( COLUMNS - $#suffix - 3 ))
+    (( max > 1 && $#msg > max )) && msg="${msg[1,max]}…"
+    zle -M "${msg}${suffix}"
     (( i = i % $#frames + 1 ))
     if [[ -n $_ZSH_AI_HAS_ZSELECT ]]; then
       zselect -t 10  # centiseconds
@@ -53,6 +65,7 @@ zsh-ai-suggest() {
     "🤖 Suggesting a command for: $BUFFER"; then
     BUFFER=$_ZSH_AI_RESPONSE
     CURSOR=$#BUFFER
+    zle -M ""  # clear the last spinner frame
     zle reset-prompt
   elif (( $? != 130 )); then
     zle -M "claude returned no suggestion; check \`claude /login\` or quota"


### PR DESCRIPTION
## Summary
#11 머지 후 보고된 화면 깨짐(같은 줄이 3번씩 쌓이는 현상) 수정입니다.

### 원인
`zle -M`의 메시지 영역은 **한 물리적 줄**일 때만 깔끔하게 다시 그려집니다. 긴 명령어가 라벨에 포함되면 메시지가 터미널 폭을 넘어 여러 줄로 래핑되고, 그 순간부터 프레임을 갱신할 때마다 이전 프레임이 잔상으로 화면에 남아 보고해주신 것처럼 줄이 계속 쌓입니다.

### 수정
- 매 프레임마다 메시지를 `COLUMNS - 접미사 길이 - 3` 으로 잘라 **항상 한 줄 안에** 들어가게 함 (말줄임표 `…` 추가, 이모지 더블폭 감안한 여유분 포함)
- 버퍼에 개행이 있으면 폭과 무관하게 래핑되므로 라벨의 개행을 공백으로 치환
- suggest 성공 시 `zle -M ""`로 마지막 스피너 프레임을 지운 뒤 `reset-prompt` (잔류 방지)

```
# Before (폭 초과 → 3줄 쌓임)
⠙ 🤖 Explaining: aws ec2 describe-instances --region ap-northeast-2 --query '...' --output table [haiku, 3s, ...]
⠙ 🤖 Explaining: aws ec2 describe-instances ... [haiku, 0s, ...]
⠋ 🤖 Explaining: aws ec2 describe-instances ... [haiku, 0s, ...]

# After (항상 한 줄, 제자리 갱신)
⠹ 🤖 Explaining: aws ec2 describe-instances --region ap-north… [haiku, 3s, Ctrl+C to cancel]
```

## Verification
- `zsh -n` 통과
- `zle` 스텁으로 COLUMNS=60/80/120/200 각각에서 전 프레임 길이가 폭 이내임을 자동 검증 (58/78/118/187자)
- 개행 포함 라벨에서 멀티라인 프레임 0건 확인