### PR TITLE
fix: render the AI spinner via POSTDISPLAY instead of zle -M

### DIFF
--- a/ai.zshrc
+++ b/ai.zshrc
@@ -8,30 +8,61 @@
 
 # Model for the inline helpers; haiku is the fastest tier
 : ${ZSH_AI_MODEL:=haiku}
+# Highlight style of the loading status (defaults to a comment-like gray)
+: ${ZSH_AI_STATUS_STYLE:=fg=244}
+# Spinner refresh interval in milliseconds
+: ${ZSH_AI_SPINNER_INTERVAL:=200}
 
 # zselect sleeps without forking; fall back to `sleep` when unavailable
 zmodload zsh/zselect 2>/dev/null && typeset -g _ZSH_AI_HAS_ZSELECT=1
 
+# Expand a leading alias in the given command line, so the LLM sees the
+# real command (e.g. `k get pods` -> `kubectl get pods`). Only the first
+# word is expanded; aliases after pipes or separators are left alone since
+# expanding them safely would require a full shell parse.
+_zsh_ai_expand_aliases() {
+  local cmd=$1
+  local first expansion
+  local -i guard=10
+  while (( guard-- > 0 )); do
+    first=${cmd%% *}
+    expansion=${aliases[$first]}
+    [[ -z $expansion || $expansion == "$first" ]] && break
+    cmd="${expansion}${cmd#"$first"}"
+    # Stop on self-referencing aliases like ssh='ssh -A'
+    [[ ${expansion%% *} == "$first" ]] && break
+  done
+  print -r -- "$cmd"
+}
+
 # Run `claude -p` in the background, animating a spinner until it finishes.
 # The response is stored in $_ZSH_AI_RESPONSE; returns non-zero when the
 # response is empty, or 130 when cancelled with Ctrl+C.
+#
+# The status line is rendered through $POSTDISPLAY (the mechanism
+# zsh-autosuggestions uses): it is part of the editor display, so zle
+# repaints it in place on every `zle -R`. Animating via `zle -M` instead
+# leaves the previous frame behind as a ghost line whenever the message
+# wraps or the prompt sits at the bottom of the screen.
 _zsh_ai_request() {
   local prompt=$1 label=$2
   local tmp pid
   tmp=$(mktemp) || return 1
   typeset -g _ZSH_AI_RESPONSE=
 
-  # The status message must stay on one physical line: when it wraps, zle's
-  # message area grows and every redraw leaves the previous frame on screen
-  # as a ghost line. Strip newlines from the label here; width-based
-  # truncation happens per frame below.
+  # Keep the status to one line: strip newlines here, truncate per frame
   label=${label//$'\n'/ }
 
   claude -p --model "$ZSH_AI_MODEL" "$prompt" > "$tmp" 2>/dev/null &!
   pid=$!
 
-  # Kill the request and clean up when the user cancels with Ctrl+C
-  trap "kill $pid 2>/dev/null; command rm -f '$tmp'; zle -M 'cancelled'; return 130" INT
+  # On Ctrl+C, kill the request and let the loop exit on its own; the
+  # normal cleanup path below restores the display
+  local cancelled=0
+  trap "kill $pid 2>/dev/null; cancelled=1" INT
+
+  local saved_postdisplay=$POSTDISPLAY
+  local -a saved_highlight=("${region_highlight[@]}")
 
   local -a frames=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')
   local i=1 start=$SECONDS
@@ -42,15 +73,29 @@ _zsh_ai_request() {
     # -3 leaves room for the ellipsis and double-width characters (emoji)
     max=$(( COLUMNS - $#suffix - 3 ))
     (( max > 1 && $#msg > max )) && msg="${msg[1,max]}…"
-    zle -M "${msg}${suffix}"
+    POSTDISPLAY=$'\n'"${msg}${suffix}"
+    # region_highlight offsets cover BUFFER followed by POSTDISPLAY
+    region_highlight=("${saved_highlight[@]}"
+      "$#BUFFER $(( $#BUFFER + $#POSTDISPLAY )) ${ZSH_AI_STATUS_STYLE}")
+    zle -R
     (( i = i % $#frames + 1 ))
     if [[ -n $_ZSH_AI_HAS_ZSELECT ]]; then
-      zselect -t 10  # centiseconds
+      zselect -t $(( ZSH_AI_SPINNER_INTERVAL / 10 ))  # centiseconds
     else
-      command sleep 0.1
+      command sleep $(( ZSH_AI_SPINNER_INTERVAL / 1000.0 ))
     fi
   done
   trap - INT
+
+  POSTDISPLAY=$saved_postdisplay
+  region_highlight=("${saved_highlight[@]}")
+  zle -R
+
+  if (( cancelled )); then
+    command rm -f "$tmp"
+    zle -M "cancelled"
+    return 130
+  fi
 
   _ZSH_AI_RESPONSE=$(<"$tmp")
   command rm -f "$tmp"
@@ -65,19 +110,21 @@ zsh-ai-suggest() {
     "🤖 Suggesting a command for: $BUFFER"; then
     BUFFER=$_ZSH_AI_RESPONSE
     CURSOR=$#BUFFER
-    zle -M ""  # clear the last spinner frame
     zle reset-prompt
   elif (( $? != 130 )); then
     zle -M "claude returned no suggestion; check \`claude /login\` or quota"
   fi
 }
 
-# Explain the command currently in the buffer
+# Explain the command currently in the buffer, with leading aliases
+# expanded so the LLM is told what will actually run
 zsh-ai-explain() {
   [[ -z $BUFFER ]] && return 0
+  local cmd
+  cmd=$(_zsh_ai_expand_aliases "$BUFFER")
   if _zsh_ai_request \
-    "Explain what this zsh command does, briefly and in plain text (no markdown): $BUFFER" \
-    "🤖 Explaining: $BUFFER"; then
+    "Explain what this zsh command does, briefly and in plain text (no markdown): $cmd" \
+    "🤖 Explaining: $cmd"; then
     zle -M "$_ZSH_AI_RESPONSE"
   elif (( $? != 130 )); then
     zle -M "claude returned no explanation; check \`claude /login\` or quota"


### PR DESCRIPTION
## Summary
#12 이후에도 중복 줄이 쌓이는 문제의 근본 수정 + 요청된 개선 3가지입니다.

### 1. 중복 줄 버그 — 렌더링 메커니즘 교체 (근본 원인)
`zle -M`은 한 줄짜리 메시지여도 프롬프트가 화면 하단 근처에 있으면 redraw마다 스크롤이 발생해 이전 프레임이 잔상으로 남습니다. 애니메이션 용도로는 구조적으로 부적합했습니다.

**`POSTDISPLAY` + `region_highlight` + `zle -R`** 조합으로 교체했습니다 — zsh-autosuggestions가 회색 제안 텍스트를 그릴 때 쓰는 바로 그 메커니즘으로, 상태 줄이 에디터 디스플레이의 일부가 되어 zle가 매 프레임 **제자리에서** 다시 그립니다. 화면에 떠 있던 autosuggestion(POSTDISPLAY)과 하이라이트는 저장 후 복원되어 충돌하지 않습니다.

### 2. 스피너 주기 200ms
`ZSH_AI_SPINNER_INTERVAL`(기본 200)로 설정 가능. zselect는 centisecond 단위라 `/10`, sleep 폴백은 `/1000.0`.

### 3. 로딩 메시지 회색(주석 톤) 표시
`region_highlight`로 상태 줄 전체에 `ZSH_AI_STATUS_STYLE`(기본 `fg=244` — 기존 `ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE`과 동일 톤) 적용.

### 4. explain 시 alias를 실제 명령으로 확장해 전달
`k get pods` → `kubectl get pods`처럼 선두 단어의 alias를 풀어서 LLM에 보냅니다. `ssh='ssh -A'` 같은 자기참조 alias는 1회만 확장하고 중단(무한루프 방지), 최대 10단계 연쇄 확장. **한계**: 파이프/세미콜론 뒤의 alias(`tf plan | g` 의 `g`)는 따옴표 안 문자열과 구분하려면 셸 파싱이 필요해 확장하지 않습니다 — 선두 명령만 확장하는 보수적 동작입니다.

## Verification
- `zsh -n` 통과
- alias 확장 단위 테스트 6케이스: 일반/자기참조/단독 단어/파이프 포함/alias 없음 모두 기대값 일치
- 스피너 메커니즘: 1.2초 가짜 claude로 redraw 7회(6프레임@200ms + 복원 1회), 종료 후 POSTDISPLAY·region_highlight가 이전 값(모의 autosuggestion)으로 정확히 복원됨을 확인
- Ctrl+C 경로 단순화: trap은 kill + 플래그만, 화면 복원은 단일 정상 경로에서 수행