### PR TITLE
feat: highlight the explanation result text

### DIFF
--- a/ai.zshrc
+++ b/ai.zshrc
@@ -10,6 +10,8 @@
 : ${ZSH_AI_MODEL:=haiku}
 # Highlight style of the loading status (defaults to a comment-like gray)
 : ${ZSH_AI_STATUS_STYLE:=fg=244}
+# Highlight style of the explanation result (defaults to bright cyan, bold)
+: ${ZSH_AI_RESULT_STYLE:=fg=14,bold}
 # Spinner refresh interval in milliseconds
 : ${ZSH_AI_SPINNER_INTERVAL:=200}
 
@@ -125,7 +127,12 @@ zsh-ai-explain() {
   if _zsh_ai_request \
     "Explain what this zsh command does, briefly and in plain text (no markdown): $cmd" \
     "🤖 Explaining: $cmd"; then
-    zle -M "$_ZSH_AI_RESPONSE"
+    # Render the explanation below the buffer through POSTDISPLAY so it can
+    # be styled with region_highlight (zle -M cannot be colored); it stays
+    # visible until the next keystroke repaints the editor
+    POSTDISPLAY=$'\n'"$_ZSH_AI_RESPONSE"
+    region_highlight+=("$#BUFFER $(( $#BUFFER + $#POSTDISPLAY )) ${ZSH_AI_RESULT_STYLE}")
+    zle -R
   elif (( $? != 130 )); then
     zle -M "claude returned no explanation; check \`claude /login\` or quota"
   fi


### PR DESCRIPTION
## Summary
explain(`Option+Shift+\`) 결과 문장을 강조 색상으로 표시합니다.

- 기존 `zle -M`은 **색상을 입힐 수 없는 API**라서, 결과 표시도 스피너(#13)와 같은 `POSTDISPLAY` + `region_highlight` 방식으로 전환
- 기본 스타일은 **bright cyan + bold** (`ZSH_AI_RESULT_STYLE=fg=14,bold`) — `fg=yellow`, `standout`, `bg=237` 등으로 자유롭게 변경 가능
- 하이라이트 범위는 설명 텍스트에만 적용되고 입력 중인 명령어는 건드리지 않음
- 설명은 다음 키 입력으로 에디터가 다시 그려질 때까지 버퍼 아래에 유지 (기존 zle -M과 동일한 수명)

## Verification
- `zsh -n` 통과
- 스텁 테스트: `k get pods -n kube-system`(25자) + 설명(65자) → region_highlight `25 90 fg=14,bold` — 오프셋이 정확히 설명 영역만 커버함을 확인
- alias 확장(#13) 경로와의 조합 동작 확인

## Note
- 잔여 하이라이트는 다음 키 입력 시 fast-syntax-highlighting이 region_highlight를 재계산하면서 정리됩니다