### PR TITLE
fix: stop autosuggestions from wiping the AI explanation

### DIFF
--- a/plugins.zshrc
+++ b/plugins.zshrc
@@ -25,7 +25,13 @@ zinit snippet OMZ::plugins/git/git.plugin.zsh
   ZSH_AUTOSUGGEST_STRATEGY=(history completion)
   # NOTE: async mode is the default since v0.7.0; no need to set it explicitly
 
+  # The AI widgets (ai.zshrc) render their result through POSTDISPLAY; if
+  # autosuggestions wraps them, its post-widget hook rewrites POSTDISPLAY
+  # and wipes the result right away. This must be appended after the plugin
+  # loads (its defaults are skipped when the variable already exists), hence
+  # inside atload rather than in ai.zshrc.
   zinit ice wait"0b" lucid atload'
+    ZSH_AUTOSUGGEST_IGNORE_WIDGETS+=(zsh-ai-suggest zsh-ai-explain)
     _zsh_autosuggest_start
     bindkey "^f" forward-word
     bindkey "^e" autosuggest-execute


### PR DESCRIPTION
## Summary
#14 머지 후 explain 결과가 아예 표시되지 않던 버그 수정입니다.

### 원인
zsh-autosuggestions는 **모든 zle 위젯을 래핑**하고, 위젯이 리턴하는 즉시 후처리 훅이 `POSTDISPLAY`를 새 제안으로 다시 씁니다 (autosuggestions 자체가 POSTDISPLAY로 회색 제안을 그리는 플러그인이라서요). 그래서:

- 스피너: 위젯 **실행 중**에 그려짐 → 후처리가 아직 안 돌아서 생존 ✅
- 설명 결과: 위젯 **마지막**에 세팅 → 리턴 직후 후처리가 덮어써서 즉시 소멸 ❌

실제로 래핑을 확인했습니다: `$widgets[zsh-ai-explain]` = `user:_zsh_autosuggest_bound_1_zsh-ai-explain`

### 수정
AI 위젯 2개를 `ZSH_AUTOSUGGEST_IGNORE_WIDGETS`에 추가해 래핑 자체를 차단합니다 (autosuggestions의 공식 설정 변수).

**위치가 ai.zshrc가 아니라 plugins.zshrc의 atload인 이유**: autosuggestions는 이 변수가 이미 존재하면 자기 기본 ignore 목록(orig-\*, zle-\* 등)을 설정하지 않습니다. ai.zshrc는 turbo 플러그인보다 먼저 소싱되므로 거기서 추가하면 기본값이 통째로 사라집니다. 플러그인 로드 직후(atload)에 append하면 기본값 + 추가분이 됩니다.

## Verification (실제 설치된 플러그인으로 검증)
- ignore 추가 후: `zsh-ai-explain`/`zsh-ai-suggest` → `user:zsh-ai-*` (언래핑) ✅
- 기본 ignore 목록 유지: `orig-* beep run-help ...` ✅
- 다른 위젯은 여전히 래핑됨 (`self-insert` → `_zsh_autosuggest_bound_1_self-insert`) → autosuggestions 기능 영향 없음 ✅
- `zsh -n` 통과