### PR TITLE
feat: register Docker CLI completions in the completion system

### DIFF
--- a/completion.zshrc
+++ b/completion.zshrc
@@ -14,6 +14,11 @@
   mkdir -p "$HOME/.zfunc"
   fpath+=("$HOME/.zfunc")
 
+  # Docker Desktop ships its CLI completions here; just register the
+  # directory and let the single compinit below pick them up
+  [ -d "$HOME/.docker/completions" ] \
+    && fpath+=("$HOME/.docker/completions")
+
   # Initialize the completion system.
   # compinit scans every directory in $fpath and writes the result to a cache
   # file (~/.zcompdump). The scan is the slow part, so run it at most once a


### PR DESCRIPTION
## Summary
Docker Desktop가 `.zshrc`에 자동 삽입하는 스니펫을 이 레포의 설정 스타일에 맞게 통합합니다.

Docker가 넣어주는 원본:
```zsh
# The following lines have been added by Docker Desktop to enable Docker CLI completions.
fpath=(/Users/bj/.docker/completions $fpath)
autoload -Uz compinit
compinit
# End of Docker CLI completions
```

이 스니펫은 fpath 등록 + **자체 compinit 호출**까지 포함하는데, 이미 `completion.zshrc`에서 compinit을 하루 캐시로 딱 한 번만 실행하도록 정리해둔 구조(#4)와 충돌합니다. 그대로 두면 compinit이 세 번째로 중복 실행됩니다.

### 변경
`completion.zshrc`의 Completion System 블록(brew/`.zfunc` fpath 등록 바로 옆)에 docker completions 디렉토리 등록만 추가하고, compinit은 기존 단일 호출이 그대로 처리하도록 했습니다.

```zsh
# Docker Desktop ships its CLI completions here; just register the
# directory and let the single compinit below pick them up
[ -d "$HOME/.docker/completions" ] \
  && fpath+=("$HOME/.docker/completions")
```

- 절대경로(`/Users/bj/...`) 대신 `$HOME` 사용
- 디렉토리 존재할 때만 등록 → Docker 미설치 머신에 영향 없음
- compinit 중복 호출 제거

## Verification
- `zsh -n` 통과
- 소싱 후 `$fpath`에 `~/.docker/completions` 등재 확인
- 해당 디렉토리에 `_docker` 함수 파일 존재 확인 (첫 탭에서 lazy-load되는 정상 동작)